### PR TITLE
Add swarm queue sensor

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -2,6 +2,9 @@
 
 **Note:** this pack is temporary and will be refactored: I'll split it by swarm pack with all swarm st2 actions and sensors, and pipelines pack with all the workflows.
 
+Don't forget to give `st2` user access to the Docker group `usermod -a -G docker st2`,
+else docker won't work.
+
 To run the pack's unit tests:
 
 ```

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -5,8 +5,10 @@
 To run the pack's unit tests:
 
 ```
-# Dang we need ST2
-git clone --depth=1 https://github.com/StackStorm/st2.git /tmp/st2
-# Run unit tests
-ST2_REPO_PATH=/tmp/st2 /opt/stackstorm/st2/bin/st2-run-pack-tests -p /opt/stackstorm/packs/pipeline
+# Activate existing pack's virtual environmet
+source /opt/stackstorm/virtualenvs/pipeline/bin/activate
+# Run the tests first time - it will install test dependencies
+t2-run-pack-tests -x /opt/stackstorm/pipeline
+# Skip installing dependencies on subsequent runs
+t2-run-pack-tests -x -j /opt/stackstorm/pipeline
 ```

--- a/pipeline/actions/job.py
+++ b/pipeline/actions/job.py
@@ -9,6 +9,7 @@ class RunJobAction(Action):
 
     def __init__(self, config):
         super(RunJobAction, self).__init__(config)
+        # TODO(dzimine): get URL from config
         self.client = docker.DockerClient(base_url='unix://var/run/docker.sock')
         self.pool_interval = 1
 
@@ -23,6 +24,7 @@ class RunJobAction(Action):
             args = [str(x) for x in args] if args else None
             mounts = [_parse_mount_string(mount) for mount in mounts] if mounts else None
 
+            # TODO(dzimine): Add label
             cs = docker.types.ContainerSpec(
                 image, command=command, args=args, mounts=mounts)
             r = {'Reservations': {'MemoryBytes': reserve_memory, 'NanoCPUs': reserve_cpu}}

--- a/pipeline/config.schema.yaml
+++ b/pipeline/config.schema.yaml
@@ -1,6 +1,18 @@
 ---
   base_url:
     description: "Docker API URL"
-    type: "string"
+    type: string
     required: true
     default: "unix://var/run/docker.sock"
+  swarm_pending_tasks_threshold:
+    description: Trigger only when pending tasks count above the threshold.
+    type: integer
+    required: false
+    default: 0
+  swarm_pending_tasks_polling_interval:
+    description: Interval for polling swarm api for tasks.
+    type: integer
+    required: true
+    default: 5
+
+

--- a/pipeline/rules/on_pending_scaleup.yaml
+++ b/pipeline/rules/on_pending_scaleup.yaml
@@ -3,16 +3,17 @@ name: on_pending_scaleup_test
 # TODO: create _aws and _openstack rules
 pack: pipeline
 description: "Scale up the Swarm when pending tasks go over threshold."
-enabled: true
+enabled: True
 
 trigger:
     type: pipeline.swarm_pending_tasks
     parameters: {}
 
 criteria:
-    trigger.count:
-        type: greaterthan
-        pattern: 2
+    # Crossing threshold up
+    trigger.over_threshold:
+        type: equals
+        pattern: True
 
 action:
     ref: core.local

--- a/pipeline/rules/on_pending_scaleup.yaml
+++ b/pipeline/rules/on_pending_scaleup.yaml
@@ -1,0 +1,20 @@
+---
+name: on_pending_scaleup_test
+# TODO: create _aws and _openstack rules
+pack: pipeline
+description: "Scale up the Swarm when pending tasks go over threshold."
+enabled: true
+
+trigger:
+    type: pipeline.swarm_pending_tasks
+    parameters: {}
+
+criteria:
+    trigger.count:
+        type: greaterthan
+        pattern: 2
+
+action:
+    ref: core.local
+    parameters:
+        cmd: echo {{ trigger.count }}

--- a/pipeline/sensors/pending_queue.py
+++ b/pipeline/sensors/pending_queue.py
@@ -1,0 +1,54 @@
+from st2reactor.sensor.base import PollingSensor
+
+import docker
+
+TRIGGER = "pipeline.sensor_task_queue"
+
+
+class SwarmPendingTasksSensor(PollingSensor):
+    """
+    Swarm pending tasks queue sensor.
+
+    Sensor polls docker swarm for the `pending` tasks
+    and dispatches the count and the list
+    """
+
+    def __init__(self, sensor_service, config=None, poll_interval=5):
+        super(SwarmPendingTasksSensor, self).__init__(sensor_service=sensor_service,
+                                                      config=config,
+                                                      poll_interval=poll_interval)
+        # TODO(dzimine): pass configurable poll_interval from cofig.
+        self._logger = self.sensor_service.get_logger(name=self.__class__.__name__)
+
+    def setup(self):
+        # TODO(dzimine): get url from config
+        self.client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+        self.threshold = self._config.get('swarm_pending_tasks_threshold', 0)
+
+    def poll(self):
+        tasks = self.client.api.tasks(filters={'desired-state': 'running'})
+        pending_tasks = [task for task in tasks if task['Status']['State'] == 'pending']
+        pending_count = len(pending_tasks)
+        if pending_count > self.threshold:
+            payload = {"count": pending_count, "tasks": pending_tasks}
+            self._logger.info(
+                'SwarmPendingTasksSensor dispatching trigger %s, payload=%s', TRIGGER, payload)
+            # TODO: add trace_tag
+            self._sensor_service.dispatch(trigger=TRIGGER, payload=payload)
+
+    def cleanup(self):
+        # This is called when the st2 system goes down. You can perform cleanup operations like
+        # closing the connections to external system here.
+        pass
+
+    def add_trigger(self, trigger):
+        # This method is called when trigger is created
+        pass
+
+    def update_trigger(self, trigger):
+        # This method is called when trigger is updated
+        pass
+
+    def remove_trigger(self, trigger):
+        # This method is called when trigger is deleted
+        pass

--- a/pipeline/sensors/pending_queue.py
+++ b/pipeline/sensors/pending_queue.py
@@ -2,7 +2,7 @@ from st2reactor.sensor.base import PollingSensor
 
 import docker
 
-TRIGGER = "pipeline.sensor_task_queue"
+TRIGGER = "pipeline.swarm_pending_tasks"
 
 
 class SwarmPendingTasksSensor(PollingSensor):

--- a/pipeline/sensors/pending_queue.yaml
+++ b/pipeline/sensors/pending_queue.yaml
@@ -3,7 +3,7 @@ entry_point: pending_queue.py
 description: "Swarm pending queue sensor"
 trigger_types:
   -
-    name: threshold
+    name: swarm_pending_tasks
     payload_schema:
       type: object
       properties:
@@ -14,5 +14,3 @@ trigger_types:
             type: array
             default: []
             description: List of swarm pending tasks.
-
-

--- a/pipeline/sensors/pending_queue.yaml
+++ b/pipeline/sensors/pending_queue.yaml
@@ -10,6 +10,9 @@ trigger_types:
           count:
             type: integer
             description: Number of pending swarm tasks.
+          over_threshold:
+            type: boolean
+            description: True if going up above threshold, False if going down below.
           tasks:
             type: array
             default: []

--- a/pipeline/sensors/pending_queue.yaml
+++ b/pipeline/sensors/pending_queue.yaml
@@ -1,0 +1,18 @@
+class_name: SwarmPendingTasksSensor
+entry_point: pending_queue.py
+description: "Swarm pending queue sensor"
+trigger_types:
+  -
+    name: threshold
+    payload_schema:
+      type: object
+      properties:
+          count:
+            type: integer
+            description: Number of pending swarm tasks.
+          tasks:
+            type: array
+            default: []
+            description: List of swarm pending tasks.
+
+

--- a/pipeline/tests/fixtures/config.yaml
+++ b/pipeline/tests/fixtures/config.yaml
@@ -1,0 +1,4 @@
+---
+base_url: "unix://var/run/docker.sock"
+swarm_pending_tasks_threshold: 1
+swarm_pending_tasks_polling_interval: 5

--- a/pipeline/tests/test_sensor_pending_queue.py
+++ b/pipeline/tests/test_sensor_pending_queue.py
@@ -39,6 +39,8 @@ class SwarmPendingTasksSensorTestCase(BaseSensorTestCase):
         self.assertEqual(
             self.get_dispatched_triggers()[0]['payload']['tasks'],
             mock_tasks.return_value)
+        self.assertEqual(
+            self.get_dispatched_triggers()[0]['payload']['over_threshold'], True)
         # Check that trigger dispatch only once
         sensor.poll()
         self.assertEqual(len(self.get_dispatched_triggers()), 1)
@@ -53,6 +55,8 @@ class SwarmPendingTasksSensorTestCase(BaseSensorTestCase):
         sensor.poll()
         # print sensor._logger.mock_calls
         self.assertTriggerDispatched(trigger=pending_queue.TRIGGER)
+        self.assertEqual(
+            self.get_dispatched_triggers()[0]['payload']['over_threshold'], False)
 
     @mock.patch('docker.api.APIClient.tasks')
     def test_poll_threshold(self, mock_tasks):

--- a/pipeline/tests/test_sensor_pending_queue.py
+++ b/pipeline/tests/test_sensor_pending_queue.py
@@ -1,0 +1,57 @@
+import mock
+from unittest2 import skip
+import yaml
+
+from st2tests.base import BaseSensorTestCase
+
+import pending_queue
+
+
+class SwarmPendingTasksSensorTestCase(BaseSensorTestCase):
+    sensor_cls = pending_queue.SwarmPendingTasksSensor
+
+    def setUp(self):
+        super(SwarmPendingTasksSensorTestCase, self).setUp()
+        self.config = yaml.safe_load(self.get_fixture_content("config.yaml"))
+
+    @mock.patch('docker.api.APIClient.tasks')
+    def test_poll_empty(self, mock_tasks):
+        mock_tasks.return_value = []
+        sensor = self.get_sensor_instance(config=self.config)
+        sensor.setup()
+        sensor.poll()
+        self.assertEqual(self.get_dispatched_triggers(), [])
+
+    @mock.patch('docker.api.APIClient.tasks')
+    def test_poll(self, mock_tasks):
+        mock_tasks.return_value = [
+            {'ID': '111', 'Status': {'State': 'pending'}},
+            {'ID': '112', 'Status': {'State': 'pending'}},
+            {'ID': '113', 'Status': {'State': 'pending'}},
+        ]
+        sensor = self.get_sensor_instance()
+        sensor.setup()
+        sensor.poll()
+        self.assertTriggerDispatched(trigger=pending_queue.TRIGGER)
+        self.assertEqual(
+            self.get_dispatched_triggers()[0]['payload']['count'],
+            len(mock_tasks.return_value))
+        self.assertEqual(
+            self.get_dispatched_triggers()[0]['payload']['tasks'],
+            mock_tasks.return_value)
+
+    @mock.patch('docker.api.APIClient.tasks')
+    def test_poll_threshold(self, mock_tasks):
+        mock_tasks.return_value = [{'ID': '111', 'Status': {'State': 'pending'}}]
+        sensor = self.get_sensor_instance(config=self.config)
+        sensor.setup()
+        sensor.poll()
+        self.assertEqual(self.get_dispatched_triggers(), [])
+
+    @skip("Only run on real swarm, with pending tasks")
+    def test_poll_real(self):
+        sensor = self.get_sensor_instance()
+        sensor.setup()
+        sensor.poll()
+        self.assertTriggerDispatched(trigger=pending_queue.TRIGGER)
+        print sensor._logger.mock_calls

--- a/pipeline/tests/test_sensor_pending_queue.py
+++ b/pipeline/tests/test_sensor_pending_queue.py
@@ -39,6 +39,20 @@ class SwarmPendingTasksSensorTestCase(BaseSensorTestCase):
         self.assertEqual(
             self.get_dispatched_triggers()[0]['payload']['tasks'],
             mock_tasks.return_value)
+        # Check that trigger dispatch only once
+        sensor.poll()
+        self.assertEqual(len(self.get_dispatched_triggers()), 1)
+
+    @mock.patch('docker.api.APIClient.tasks')
+    def test_going_below_threshlold(self, mock_tasks):
+        mock_tasks.return_value = [{'ID': '111', 'Status': {'State': 'pending'}}]
+        sensor = self.get_sensor_instance()
+        sensor.setup()
+        sensor.threshold = 2
+        sensor.over_threshold = True
+        sensor.poll()
+        # print sensor._logger.mock_calls
+        self.assertTriggerDispatched(trigger=pending_queue.TRIGGER)
 
     @mock.patch('docker.api.APIClient.tasks')
     def test_poll_threshold(self, mock_tasks):


### PR DESCRIPTION
- [x] Basic sensor & unit tests
- [x] Final naming
- [x] Option to trigger once (per threshold cross) or ~~trigger every time~~
    - Decided for trigger once on crossing threshold on way up, or down
- [x] Sample rule
- [x] More unit tests

To test it: 
* ensure the sensor and rule are enabled 
* with default threshold `1`, create a service with large memory reservation
```
docker service create  --reserve-memory 2Gb --restart-condition none nginx
```
* this should emit a trigger, and trip the rule
* don't forget to remove the large service
